### PR TITLE
Add parsing for Breaker control state and Number of power failures

### DIFF
--- a/dsmr/frame.go
+++ b/dsmr/frame.go
@@ -25,7 +25,7 @@ var (
 	// Regexp that matches most of the objects groups with 2 groups:
 	//  - OBIS Reduced ID-code eg `1-0:1.8.1`
 	//  - Value eg `(000084.276*kWh)`
-	objectRegexp = regexp.MustCompile("([0-9]+\\-[0-9]+\\:[0-9]+\\.[0-9]+\\.[0-9])\\((.*)\\)")
+	objectRegexp = regexp.MustCompile("([0-9]+-[0-9]+:[0-9]+.[0-9]+.[0-9]+)\\((.*)\\)")
 	// defaultValueRegexp extract value and unit with 2 groups:
 	//  - Value eg `000084.276`
 	//  - Unit (optional) eg `kWh`

--- a/dsmr/frame_test.go
+++ b/dsmr/frame_test.go
@@ -45,6 +45,24 @@ func TestParseObject(t *testing.T) {
 	if d.Unit != want {
 		t.Errorf("unit does not match %q != %q", d.Unit, want)
 	}
+
+	//Double last OBIS digit
+	do = "0-0:96.7.21(00001)"
+	d, err = ParseObject(do)
+	if err != nil {
+		t.Error(err)
+	}
+	t.Logf("DO: %v", d)
+
+	want = "00001"
+	if d.Value != want {
+		t.Errorf("value does not match %q != %q", d.Value, want)
+	}
+
+	want = ""
+	if d.Unit != want {
+		t.Errorf("unit does not match %q != %q", d.Unit, want)
+	}
 }
 
 func TestParseFrame(t *testing.T) {


### PR DESCRIPTION
Breaker control state and Number of power failures have a 2 digit ending
OBIS code which was not allowed in the original objectRegexp, thus the
values were simply dropped.
I extended the TestParseObject test case to cover this as well.