### PR TITLE
Update golang version for Prometheus client

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM golang:1.11-alpine as builder
+FROM golang:1.13-alpine as builder
 RUN apk update && apk add git
 COPY . /go/src/github.com/basvdlei/gotsmart
 WORKDIR /go/src/github.com/basvdlei/gotsmart


### PR DESCRIPTION
Hi,

I encountered a problem while building the application in docker.

```
# github.com/prometheus/client_golang/prometheus
go/src/github.com/prometheus/client_golang/prometheus/go_collector.go:388:15: undefined: debug.ReadBuildInfo
```

Apparently. prometheus requires a more recent version of Go to function.