### PR TITLE
Add support for Belgium gas meter and voltage info

### DIFF
--- a/dsmr/frame.go
+++ b/dsmr/frame.go
@@ -25,7 +25,7 @@ var (
 	// Regexp that matches most of the objects groups with 2 groups:
 	//  - OBIS Reduced ID-code eg `1-0:1.8.1`
 	//  - Value eg `(000084.276*kWh)`
-	objectRegexp = regexp.MustCompile("([0-9]+-[0-9]+:[0-9]+.[0-9]+.[0-9]+)\\((.*)\\)")
+	objectRegexp = regexp.MustCompile("([0-9]+-[0-9]+:[0-9]+.[0-9]+.[0-9]+).*\\(([^()]*)\\)")
 	// defaultValueRegexp extract value and unit with 2 groups:
 	//  - Value eg `000084.276`
 	//  - Unit (optional) eg `kWh`

--- a/dsmr/frame_test.go
+++ b/dsmr/frame_test.go
@@ -25,7 +25,33 @@ var (
 1-0:31.7.0(002*A)
 1-0:21.7.0(00.372*kW)
 1-0:22.7.0(00.000*kW)
+0-1:24.4.0(1)
+0-1:24.2.3(1234ABC)(00001.234*m3)
 !`
+	frameWant = map[string]struct {
+		value string
+		unit  string
+	}{
+		"1-0:1.8.1":   {value: "000093.179", unit: "kWh"},
+		"1-0:1.8.2":   {value: "000056.684", unit: "kWh"},
+		"1-0:2.8.1":   {value: "000000.000", unit: "kWh"},
+		"1-0:2.8.2":   {value: "000000.000", unit: "kWh"},
+		"0-0:96.14.0": {value: "0001"},
+		"1-0:1.7.0":   {value: "00.372", unit: "kW"},
+		"1-0:2.7.0":   {value: "00.000", unit: "kW"},
+		"0-0:96.7.21": {value: "00001"},
+		"0-0:96.7.9":  {value: "00000"},
+		"1-0:99.97.0": {value: "0-0:96.7.19"},
+		"1-0:32.32.0": {value: "00000"},
+		"1-0:32.36.0": {value: "00000"},
+		"0-0:96.13.1": {},
+		"0-0:96.13.0": {},
+		"1-0:31.7.0":  {value: "002", unit: "A"},
+		"1-0:21.7.0":  {value: "00.372", unit: "kW"},
+		"1-0:22.7.0":  {value: "00.000", unit: "kW"},
+		"0-1:24.4.0":  {value: "1"},
+		"0-1:24.2.3":  {value: "00001.234", unit: "m3"},
+	}
 )
 
 func TestParseObject(t *testing.T) {
@@ -63,6 +89,42 @@ func TestParseObject(t *testing.T) {
 	if d.Unit != want {
 		t.Errorf("unit does not match %q != %q", d.Unit, want)
 	}
+
+	//With 2 values
+	do = "0-1:24.2.3(123ABC)(0012.345*m3)"
+	d, err = ParseObject(do)
+	if err != nil {
+		t.Error(err)
+	}
+	t.Logf("DO: %v", d)
+
+	want = "0012.345"
+	if d.Value != want {
+		t.Errorf("value does not match %q != %q", d.Value, want)
+	}
+
+	want = "m3"
+	if d.Unit != want {
+		t.Errorf("unit does not match %q != %q", d.Unit, want)
+	}
+
+	//Double last OBIS digit
+	do = "0-0:96.7.21(00001)"
+	d, err = ParseObject(do)
+	if err != nil {
+		t.Error(err)
+	}
+	t.Logf("DO: %v", d)
+
+	want = "00001"
+	if d.Value != want {
+		t.Errorf("value does not match %q != %q", d.Value, want)
+	}
+
+	want = ""
+	if d.Unit != want {
+		t.Errorf("unit does not match %q != %q", d.Unit, want)
+	}
 }
 
 func TestParseFrame(t *testing.T) {
@@ -73,4 +135,21 @@ func TestParseFrame(t *testing.T) {
 	}
 
 	t.Logf("Frame: %v", f)
+
+	if len(f.Objects) != len(frameWant) {
+		t.Errorf("size does not match %d != %d", len(f.Objects), len(frameWant))
+	}
+	for k, want := range frameWant {
+		got, ok := f.Objects[k]
+		if !ok {
+			t.Errorf("key %v not found", k)
+			continue
+		}
+		if got.Value != want.value {
+			t.Errorf("value does not match for key %s : %s != %s", k, got.Value, want.value)
+		}
+		if got.Unit != want.unit {
+			t.Errorf("unit does not match for key %s : %s != %s", k, got.Unit, want.unit)
+		}
+	}
 }

--- a/dsmr/prometheus/metricbuilder.go
+++ b/dsmr/prometheus/metricbuilder.go
@@ -322,6 +322,42 @@ var metricBuilders = map[string]MetricBuilder{
 		),
 		Unit: "A",
 	},
+	// Instantaneous voltage L1 in A resolution.  1-0:31.7.0.255  2 Value 3
+	// Register F3(0,0), tag 18  A
+	"1-0:32.7.0": MetricBuilder{
+		ValueType: prometheus.GaugeValue,
+		Desc: prometheus.NewDesc(
+			namespace+"_voltage_l1_a",
+			"instantaneous voltage l1 in a resolution",
+			defaultLabels,
+			prometheus.Labels{},
+		),
+		Unit: "V",
+	},
+	// Instantaneous voltage L2 in A resolution.  1-0:51.7.0.255  2 Value 3
+	// Register F3(0,0), tag 18  A
+	"1-0:52.7.0": MetricBuilder{
+		ValueType: prometheus.GaugeValue,
+		Desc: prometheus.NewDesc(
+			namespace+"_voltage_l2_a",
+			"instantaneous voltage l2 in a resolution",
+			defaultLabels,
+			prometheus.Labels{},
+		),
+		Unit: "V",
+	},
+	// Instantaneous voltage L3 in A resolution.  1-0:71.7.0.255  2 Value 3
+	// Register F3(0,0), tag 18  A
+	"1-0:72.7.0": MetricBuilder{
+		ValueType: prometheus.GaugeValue,
+		Desc: prometheus.NewDesc(
+			namespace+"_voltage_l3_a",
+			"instantaneous voltage l3 in a resolution",
+			defaultLabels,
+			prometheus.Labels{},
+		),
+		Unit: "V",
+	},
 	// Instantaneous active power L1 (+P) in W resolution 1-0:21.7.0.255  2
 	// Value 3 Register F5(3,3), tag 18  kW
 	"1-0:21.7.0": MetricBuilder{
@@ -393,6 +429,31 @@ var metricBuilders = map[string]MetricBuilder{
 			prometheus.Labels{},
 		),
 		Unit: "kW",
+	},
+
+	// Switch position Gas
+
+	"0-1:24.4.0": MetricBuilder{
+		ValueType: prometheus.UntypedValue,
+		Desc: prometheus.NewDesc(
+			namespace+"_gas_switch",
+			"gas switch",
+			defaultLabels,
+			prometheus.Labels{},
+		),
+	},
+
+	// Reading from natural gas meter (timestamp) (value)
+
+	"0-1:24.2.3": MetricBuilder{
+		ValueType: prometheus.CounterValue,
+		Desc: prometheus.NewDesc(
+			namespace+"_gas_m3",
+			"actual gas volume delivered",
+			defaultLabels,
+			prometheus.Labels{},
+		),
+		Unit: "m3",
 	},
 
 	// TODO The types below are Smart Meter extensions like Gas meter, etc.


### PR DESCRIPTION
Adds support for voltage info, and gas meter.

More info on the IDs used in Belgium: https://jensd.be/1183/linux/read-data-from-the-belgian-digital-meter-through-the-p1-port